### PR TITLE
Handle nullable milestone due dates

### DIFF
--- a/Gitea/Milestones/NewMilestoneView.swift
+++ b/Gitea/Milestones/NewMilestoneView.swift
@@ -27,7 +27,7 @@ struct NewMilestoneView: View {
 				body: .json(
 					.init(
 						description: description,
-						dueOn: dueDate,
+						dueOn: setDueDate ? dueDate : nil,
 						state: .open,
 						title: title
 					))

--- a/Gitea/openapi.yaml
+++ b/Gitea/openapi.yaml
@@ -17932,6 +17932,7 @@ components:
         due_on:
           type: string
           format: date-time
+          nullable: true
           x-go-name: Deadline
         state:
           type: string
@@ -19061,6 +19062,7 @@ components:
           description: Deadline is the updated due date for the milestone
           type: string
           format: date-time
+          nullable: true
           x-go-name: Deadline
         state:
           description: State indicates the updated state of the milestone
@@ -21080,6 +21082,7 @@ components:
         due_on:
           type: string
           format: date-time
+          nullable: true
           x-go-name: Deadline
         id:
           description: ID is the unique identifier for the milestone


### PR DESCRIPTION
## Summary

This fixes a decoding failure when loading issues that contain a milestone without a due date.

The app can currently fail while invoking `issueSearchIssues` with an error like:

```text
DecodingError.valueNotFound: Expected value of type Date but found null instead.
Path: [0].milestone.due_on
```

## Cause

`Components.Schemas.Milestone.due_on` is generated from `Gitea/openapi.yaml` as a non-null `Date`, but Gitea responses may include milestones where `due_on` is `null`.

Since issue search responses embed `Milestone`, a single issue with a milestone that has no due date can make the whole issues list fail to decode.

## Changes

- Marked milestone `due_on` fields as `nullable: true` in the OpenAPI schema for:
  - `CreateMilestoneOption`
  - `EditMilestoneOption`
  - `Milestone`
- Updated `NewMilestoneView` so the `Set due date` toggle is respected and `nil` is sent when no due date is selected.

## Verification

- Ran:

```sh
xcodebuild \
  -project Gitea.xcodeproj \
  -scheme Gitea \
  -destination 'generic/platform=iOS Simulator' \
  -skipPackagePluginValidation \
  CODE_SIGNING_ALLOWED=NO \
  build
```

Swift compilation reached the app target and compiled the generated OpenAPI sources with the nullable due date changes. The local build then failed in asset catalog compilation because the checkout has an unresolved Git LFS pointer for `Gitea/AppIcon.icon/Assets/3dicons-tea-cup-front-premium.png` (`git-lfs` is not installed in my environment), so Xcode cannot create the app icon image locally. No Swift compile errors were reported for this change.
