### PR TITLE
Fix activity issue navigation

### DIFF
--- a/Gitea/Activity/ActivityView.swift
+++ b/Gitea/Activity/ActivityView.swift
@@ -58,10 +58,11 @@ struct ActivityView: View {
 		let owner = activity.repo.owner.login
 		let repo = activity.repo.name
 		let ref = activity.refName
+		let contentIndex = activity.contentIndex
 
 		switch activity.opType {
 		case .createIssue, .commentIssue, .closeIssue, .reopenIssue:
-			if let index = Int64(ref) {
+			if let index = Int64(ref) ?? contentIndex {
 				IssueLoader(owner: owner, repo: repo, index: index)
 			} else {
 				FullRepoView(activity.repo)
@@ -69,7 +70,7 @@ struct ActivityView: View {
 		case .createPullRequest, .mergePullRequest, .closePullRequest, .reopenPullRequest,
 			.commentPull, .approvePullRequest, .rejectPullRequest, .pullReviewDismissed,
 			.pullRequestReadyForReview, .autoMergePullRequest:
-			if let index = Int64(ref) {
+			if let index = Int64(ref) ?? contentIndex {
 				PullRequestLoader(owner: owner, repo: repo, index: index)
 			} else {
 				FullRepoView(activity.repo)
@@ -280,5 +281,12 @@ struct ActivityView: View {
 		default:
 			return Text(" acted")
 		}
+	}
+}
+
+private extension Components.Schemas.Activity {
+	var contentIndex: Int64? {
+		let prefix = content.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false).first
+		return prefix.flatMap { Int64($0) }
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #3 by making activity navigation fall back to the activity content payload when `ref_name` is empty. Gitea issue and pull request activities can encode the target number as the leading value in `content`, for example `379|...`, while leaving `ref_name` blank.

## What changed

- Keep using `ref_name` when it contains the issue or pull request number.
- Fall back to the leading numeric value from `content` for issue and pull request activities.
- Preserve the existing repository fallback when neither field contains a usable number.

## Validation

- Built and launched the app on iOS Simulator with XcodeBuildMCP.
- Command used internally: `build_run_sim` with `-skipPackagePluginValidation`.

## Notes

This PR is intentionally limited to the activity navigation fix. No icon, asset, or unrelated UI changes are included.