### PR TITLE
Support custom Gitea instance URLs

### DIFF
--- a/Gitea/Auth/ConfigView.swift
+++ b/Gitea/Auth/ConfigView.swift
@@ -12,19 +12,9 @@ struct ConfigView: View {
 
 	public private(set) var showSetup: Binding<Bool>? = nil
 
-	@State private var newHost = "gitea.com"
+	@State private var newURL = "https://gitea.com"
 	@State private var newToken = ""
 	@State private var errorMessage: LocalizedStringKey?
-
-	private func sanitizeHost(_ input: String) -> String {
-		let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-		if trimmed.contains("/") {
-			if let tempUrl = URL(string: trimmed), let host = tempUrl.host {
-				return host
-			}
-		}
-		return trimmed
-	}
 
 	var body: some View {
 		Form {
@@ -39,7 +29,7 @@ struct ConfigView: View {
 
 			Section(
 				content: {
-					TextField("gitea.example.com", text: $newHost)
+					TextField("https://gitea.example.com", text: $newURL)
 						.keyboardType(.URL)
 						.textInputAutocapitalization(.never)
 						.autocorrectionDisabled()
@@ -77,9 +67,8 @@ struct ConfigView: View {
 		}.toolbar {
 			AsyncButton("Save") {
 				errorMessage = nil
-				let host = sanitizeHost(newHost)
-				guard host.isNotEmpty else {
-					errorMessage = "Please provide a valid host"
+				guard let instance = GiteaInstance(serverURLString: newURL, token: newToken) else {
+					errorMessage = "Please provide a valid URL"
 					return
 				}
 				guard newToken.isNotEmpty else {
@@ -88,7 +77,6 @@ struct ConfigView: View {
 				}
 
 				do {
-					let instance = GiteaInstance(host: host, token: newToken)
 					try await Auth.login(
 						instance: instance,
 						showSetup: showSetup,

--- a/Gitea/Auth/GiteaInstance.swift
+++ b/Gitea/Auth/GiteaInstance.swift
@@ -8,12 +8,107 @@
 import Foundation
 
 struct GiteaInstance: Codable, Identifiable, Equatable {
-	let host: String
+	let baseURL: URL
 	let token: String
 
-	var id: String { host }
+	var id: String { baseURL.absoluteString }
 
 	var serverURL: URL {
-		URL(string: "https://\(host)/api/v1")!
+		baseURL.appendingPathComponent("api").appendingPathComponent("v1")
+	}
+
+	var displayURL: String {
+		baseURL.absoluteString
+	}
+
+	init(baseURL: URL, token: String) {
+		self.baseURL = baseURL
+		self.token = token
+	}
+
+	init?(serverURLString: String, token: String) {
+		guard let baseURL = Self.normalizedBaseURL(from: serverURLString) else {
+			return nil
+		}
+
+		self.init(baseURL: baseURL, token: token)
+	}
+
+	static func normalizedBaseURL(from string: String) -> URL? {
+		let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard trimmed.isNotEmpty else { return nil }
+
+		let withScheme = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+		guard let url = URL(string: withScheme) else { return nil }
+
+		return normalizedBaseURL(from: url)
+	}
+
+	static func normalizedBaseURL(from url: URL) -> URL? {
+		guard let scheme = url.scheme?.lowercased(),
+			["http", "https"].contains(scheme),
+			let host = url.host?.lowercased(),
+			host.isNotEmpty
+		else {
+			return nil
+		}
+
+		var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+		components?.scheme = scheme
+		components?.host = host
+		components?.user = nil
+		components?.password = nil
+		components?.query = nil
+		components?.fragment = nil
+
+		let normalizedPath = normalizedBasePath(url.path)
+		components?.path = normalizedPath.isEmpty ? "" : normalizedPath
+
+		return components?.url
+	}
+
+	private static func normalizedBasePath(_ path: String) -> String {
+		var components = path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+
+		if components.suffix(2).map({ $0.lowercased() }) == ["api", "v1"] {
+			components.removeLast(2)
+		}
+
+		return components.isEmpty ? "" : "/" + components.joined(separator: "/")
+	}
+}
+
+extension GiteaInstance {
+	enum CodingKeys: String, CodingKey {
+		case baseURL, token, host
+	}
+
+	init(from decoder: any Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		token = try container.decode(String.self, forKey: .token)
+
+		if let baseURL = try container.decodeIfPresent(URL.self, forKey: .baseURL),
+			let normalized = Self.normalizedBaseURL(from: baseURL)
+		{
+			self.baseURL = normalized
+			return
+		}
+
+		let host = try container.decode(String.self, forKey: .host)
+		guard let baseURL = Self.normalizedBaseURL(from: host) else {
+			throw DecodingError.dataCorruptedError(
+				forKey: .host,
+				in: container,
+				debugDescription: "Invalid Gitea instance URL: \(host)"
+			)
+		}
+
+		self.baseURL = baseURL
+	}
+
+	func encode(to encoder: any Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
+		try container.encode(baseURL, forKey: .baseURL)
+		try container.encode(token, forKey: .token)
 	}
 }

--- a/Gitea/Auth/InstanceManager.swift
+++ b/Gitea/Auth/InstanceManager.swift
@@ -14,7 +14,7 @@ class InstanceManager {
 	private static let selectedKey = "selectedInstance"
 
 	// This is a fallback which should hopefully never be used
-	static let defaultInstance = GiteaInstance(host: "gitea.com", token: "")
+	static let defaultInstance = GiteaInstance(baseURL: URL(string: "https://gitea.com")!, token: "")
 
 	static let minimumRequiredVersion = "1.26.0"
 
@@ -65,6 +65,13 @@ class InstanceManager {
 				let instances = try? JSONDecoder().decode([GiteaInstance].self, from: data)
 			else {
 				return []
+			}
+			if let selectedId,
+				!instances.contains(where: { $0.id == selectedId }),
+				let migratedId = GiteaInstance.normalizedBaseURL(from: selectedId)?.absoluteString,
+				instances.contains(where: { $0.id == migratedId })
+			{
+				self.selectedId = migratedId
 			}
 			return instances
 		}

--- a/Gitea/Auth/InstancesView.swift
+++ b/Gitea/Auth/InstancesView.swift
@@ -59,7 +59,7 @@ struct InstancesView: View {
 			} else {
 				ForEach(instances) { instance in
 					HStack {
-						Text(instance.host)
+						Text(instance.displayURL)
 
 						Spacer()
 						statusView(for: instance)

--- a/Gitea/Auth/Network.swift
+++ b/Gitea/Auth/Network.swift
@@ -14,7 +14,7 @@ class Network {
 
 	public static var shared: GiteaClient {
 		let instance = InstanceManager.selected ?? InstanceManager.defaultInstance
-		let key = "\(instance.host):\(instance.token)"
+		let key = "\(instance.baseURL.absoluteString):\(instance.token)"
 		if _instanceKey != key {
 			_client = GiteaClient(serverURL: instance.serverURL, token: instance.token)
 			_instanceKey = key

--- a/Gitea/Base/HomeView.swift
+++ b/Gitea/Base/HomeView.swift
@@ -15,9 +15,9 @@ struct HomeView: View {
 
 	private func load() async {
 		if let version = try? await Network.shared.client.getVersion().ok.body.json.version {
-			let host = InstanceManager.selected?.host ?? ""
+			let instanceURL = InstanceManager.selected?.displayURL ?? ""
 			if InstanceManager.compareVersions(version, InstanceManager.minimumRequiredVersion) == .orderedAscending,
-				InstanceManager.shouldShowVersionWarning(for: host, serverVersion: version)
+				InstanceManager.shouldShowVersionWarning(for: instanceURL, serverVersion: version)
 			{
 				versionWarning = version
 			} else {
@@ -44,8 +44,8 @@ struct HomeView: View {
 					)
 					.swipeActions {
 						Button("Acknowledge", systemImage: "xmark") {
-							let host = InstanceManager.selected?.host ?? ""
-							InstanceManager.acknowledgeVersionWarning(for: host, serverVersion: versionWarning)
+							let instanceURL = InstanceManager.selected?.displayURL ?? ""
+							InstanceManager.acknowledgeVersionWarning(for: instanceURL, serverVersion: versionWarning)
 							self.versionWarning = nil
 						}
 					}


### PR DESCRIPTION
Fixes #6.

This follows the direction of `allow-custom-url` while keeping the patch scoped to instance URL handling.

Changes:
- Store a normalized base URL instead of a host-only value.
- Preserve scheme, port, and optional subpath for self-hosted instances.
- Accept host-only input by defaulting to `https://`.
- Strip a trailing `/api/v1` before appending the API path, so it is not duplicated.
- Migrate existing host-based saved instances and selected instance IDs.

Validation:
- `xcodebuild -project Gitea.xcodeproj -scheme Gitea -configuration Debug -destination "generic/platform=iOS Simulator" -skipPackagePluginValidation build`